### PR TITLE
Add mode configuration option to enable strict type checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,22 @@ This will produce a file called `lib/index.js.flow` alongside the normal `lib/in
 export * from '../src/index.js'
 ```
 
-This plugin doesn't take any configuration options.
+## Flow Strict
+
+If you want to enable stricter type checking, pass a `mode`
+into configuration options:
+
+```js
+export default {
+  input: './src/index.js',
+  output: { file: './lib/index.js', format: 'cjs' },
+  plugins: [
+    flowEntry({
+      mode: 'strict-local',
+    })
+  ]
+}
+```
 
 ## Multiple Entry Points
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,8 @@ import path from 'path'
 
 const multiEntryId = '\0rollup-plugin-multi-entry:entry-point'
 
-export default function flowEntry () {
+export default function flowEntry (config = {}) {
+  const mode = config.mode ? ` ${config.mode}` : ''
   let savedMultiEntry
 
   return {
@@ -34,7 +35,7 @@ export default function flowEntry () {
         if (file.facadeModuleId !== multiEntryId) {
           // Normal files:
           const path = fixPath(file.facadeModuleId)
-          const source = `// @flow\n\nexport * from '${path}'\n`
+          const source = `// @flow${mode}\n\nexport * from '${path}'\n`
           const fileName = file.fileName + '.flow'
           bundle[fileName] = { fileName, isAsset: true, source }
         } else {
@@ -46,7 +47,7 @@ export default function flowEntry () {
             continue
           }
 
-          let source = '// @flow\n\n'
+          let source = `// @flow${mode}\n\n`
           const lines = savedMultiEntry.split('\n')
           for (const line of lines) {
             const quoted = line.replace(/^export \* from (".*");/, '$1')

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -31,6 +31,24 @@ describe('rollup-plugin-flow-entry', function () {
       })
   })
 
+  it('handles single entry point in strict mode', function () {
+    return rollup({
+      input: 'test/demo/entry1.js',
+      plugins: [flowEntry({ mode: 'strict' }), babel(babelOpts)]
+    })
+      .then(bundle =>
+        bundle.generate({ file: 'test/tmp/output.js', format: 'cjs' })
+      )
+      .then(({ output }) => {
+        expect(output).has.lengthOf(2)
+        expect(output).to.deep.include({
+          fileName: 'output.js.flow',
+          isAsset: true,
+          source: "// @flow strict\n\nexport * from '../demo/entry1.js'\n"
+        })
+      })
+  })
+
   it('handles multiple entry points', function () {
     return rollup({
       input: ['test/demo/entry1.js', 'test/demo/entry2.js'],
@@ -63,6 +81,29 @@ describe('rollup-plugin-flow-entry', function () {
       .then(({ output }) => {
         const expected =
           '// @flow\n\n' +
+          "export * from '../demo/entry1.js'\n" +
+          "export * from '../demo/entry2.js'\n"
+
+        expect(output).has.lengthOf(2)
+        expect(output).to.deep.include({
+          fileName: 'output.js.flow',
+          isAsset: true,
+          source: expected
+        })
+      })
+  })
+
+  it('works with rollup-plugin-multi-entry in strict mode', function () {
+    return rollup({
+      input: 'test/demo/entry*.js',
+      plugins: [flowEntry({ mode: 'strict' }), multiEntry(), babel(babelOpts)]
+    })
+      .then(bundle =>
+        bundle.generate({ file: 'test/tmp/output.js', format: 'cjs' })
+      )
+      .then(({ output }) => {
+        const expected =
+          '// @flow strict\n\n' +
           "export * from '../demo/entry1.js'\n" +
           "export * from '../demo/entry2.js'\n"
 


### PR DESCRIPTION
This allows one to enable flow's strict type checking: https://flow.org/en/docs/strict/.
A `mode` configuration option may be passed in so that strict or strict-local is enabled.

For example:

```js
import flowEntry from 'rollup-plugin-flow-entry'

export default {
  input: './src/index.js',
  output: { file: './lib/index.js', format: 'cjs' },
  plugins: [
    flowEntry({ mode: 'strict-local' })
  ]
}
```

Would yield:

```js
// @flow strict-local

export * from '../src/index.js'
```